### PR TITLE
SPR-139 Add continue on error property

### DIFF
--- a/.github/workflows/api-build-deploy.yaml
+++ b/.github/workflows/api-build-deploy.yaml
@@ -71,6 +71,7 @@ jobs:
           ./.github/helpers/deploy.sh
 
       - name: Rollout Pod
+        continue-on-error: true
         run: |
           oc rollout latest dc/spr-api
 

--- a/.github/workflows/app-build-deploy.yaml
+++ b/.github/workflows/app-build-deploy.yaml
@@ -67,6 +67,7 @@ jobs:
           ./.github/helpers/deploy.sh
 
       - name: Rollout Pod
+        continue-on-error: true
         run: |
           oc rollout latest dc/spr-app
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Adds continue-on-error property to explicit rollout command. Otherwise, it fails the workflow if the previous step actually kicks off the rollout. This explicit workflow should just be a fallback for when the pod is not redeployed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
- [ ] Dependencies added/removed

## Aspect(s) of Project Affected
- [ ] Frontend
- [ ] API
- [ ] Database
- [x] Workflows
- [ ] Documentation

## Best Practices Checklist
- [x] I have performed a self-review of my own code
- [x] My code follows the Airbnb React Style Guidelines
- [ ] Documentation has been updated to reflect my changes
- [x] New and existing tests pass locally with my changes

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

