### PR TITLE
SPR-145 Add swagger redirect and streamline testing constant

### DIFF
--- a/api/constants/Constants.ts
+++ b/api/constants/Constants.ts
@@ -18,7 +18,7 @@ if (ENVIRONMENT && ENVIRONMENT === 'local') {
 
 const Constants = {
   API_PORT: API_PORT || 3004,
-  TESTING: TESTING || false,
+  TESTING: `${TESTING}`.toLowerCase() !== 'true',
   BACKEND_URL: backendUrl,
   FRONTEND_URL: frontendUrl
 };

--- a/api/controllers/swagger-redirect-controller.ts
+++ b/api/controllers/swagger-redirect-controller.ts
@@ -1,0 +1,8 @@
+import { Request, Response } from 'express';
+import Constants from '../constants/Constants';
+
+// Used to redirect to Swagger page from other pages  
+export const swaggerRedirect = async (req: Request, res: Response) => {
+  const { BACKEND_URL } = Constants;
+  return res.redirect(`${BACKEND_URL}/api/docs`);
+}

--- a/api/express.ts
+++ b/api/express.ts
@@ -72,8 +72,13 @@ const headerHandler: unknown = (req: Request, res: Response, next: NextFunction)
 }
 app.use('/api', headerHandler as RequestHandler);
 
-if (`${TESTING}`.toLowerCase() !== 'true') app.use(limiter);
+// Use rate limiter if not testing
+if (TESTING) app.use(limiter);
+
+// Swagger service route
 app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerJSDoc(OPENAPI_OPTIONS)));
+// Swagger redirect service routes
+app.use('/api', openRouter.swaggerRouter);
 
 // Routing Open Routes
 app.use('/api', openRouter.chefsRouter);
@@ -83,7 +88,7 @@ app.use('/api', openRouter.healthRouter);
 // Pass the request through with no protection (for testing)
 const falseProtect: unknown = (req: Request, res: Response, next: NextFunction) => { console.warn('Keycloak is off'); next(); }
 // Allow for removed protection when API testing is enabled, otherwise use Keycloak
-const routeProtector : (RequestHandler | Promise<Response<any, Record<string, any>>>) = `${TESTING}`.toLowerCase() === 'true' ? (falseProtect as RequestHandler) : protect;
+const routeProtector : (RequestHandler | Promise<Response<any, Record<string, any>>>) = TESTING ? (falseProtect as RequestHandler) : protect;
 app.use('/api', routeProtector, protectedRouter.requests);
 
 

--- a/api/routes/open/index.ts
+++ b/api/routes/open/index.ts
@@ -1,9 +1,11 @@
 import healthRouter from './health-router';
 import chefsRouter from './chefs-router';
+import swaggerRouter from './swagger-router';
 
 const openRouter = {
   healthRouter,
-  chefsRouter
+  chefsRouter,
+  swaggerRouter
 };
 
 export default openRouter;

--- a/api/routes/open/swagger-router.ts
+++ b/api/routes/open/swagger-router.ts
@@ -1,0 +1,12 @@
+import express from 'express';
+import { swaggerRedirect } from '../../controllers/swagger-redirect-controller';
+
+const router = express.Router();
+
+router.route('/')
+  .get(swaggerRedirect);
+
+router.route('/api-docs')
+  .get(swaggerRedirect);
+
+export default router;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Added redirect routes so root and api-docs will always redirect to the swagger page.
- TESTING env is only determined in constants now. Every TESTING usage comes from there.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
- [ ] Dependencies added/removed

## Aspect(s) of Project Affected
- [ ] Frontend
- [x] API
- [ ] Database
- [ ] Workflows
- [ ] Documentation

## Best Practices Checklist
- [x] I have performed a self-review of my own code
- [x] My code follows the Airbnb React Style Guidelines
- [ ] Documentation has been updated to reflect my changes
- [x] New and existing tests pass locally with my changes

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Tested locally