### PR TITLE
SPR-117 Get Records Based on IDIR

### DIFF
--- a/api/controllers/requests-api-controller.ts
+++ b/api/controllers/requests-api-controller.ts
@@ -92,9 +92,11 @@ export const getAllRequests = async (req: Request, res: Response) => {
 export const getRequestsByIDIR = async (req: Request, res: Response) => {
   const { minimal, idir } = req.query;
 
-  // Check if user's IDIR matches
+  // If neither the IDIR matches nor the user is admin, return the 403
   const userInfo = getUserInfo(req.headers.authorization.split(' ')[1]); // Excludes the 'Bearer' part of token.
-  if (userInfo.idir_user_guid !== idir && !userInfo.client_roles?.includes('admin')) return res.status(403).send('Forbidden: User does not match requested IDIR.');
+  const idirMatches = userInfo.idir_user_guid === idir;
+  const isAdmin = userInfo.client_roles?.includes('admin');
+  if (!idirMatches && !isAdmin) return res.status(403).send('Forbidden: User does not match requested IDIR.');
 
   try {
     const cursor = minimal === 'true'
@@ -138,8 +140,11 @@ export const getRequestByID = async (req: Request, res: Response) => {
       return res.status(404).send('No record with that ID found.');
     }
     if (record){
+      // If neither the IDIR matches nor the user is admin, return the 403      
       const userInfo = getUserInfo(req.headers.authorization.split(' ')[1]); // Excludes the 'Bearer' part of token.
-      if (userInfo.idir_user_guid !== record.idir && !userInfo.client_roles?.includes('admin')) return res.status(403).send('Forbidden: User does not match requested record.');
+      const idirMatches = userInfo.idir_user_guid === record.idir;
+      const isAdmin = userInfo.client_roles?.includes('admin');
+      if (!idirMatches && !isAdmin) return res.status(403).send('Forbidden: User does not match requested record.');
       return res.status(200).json(record);
     }
   } catch (e) {
@@ -183,8 +188,11 @@ export const updateRequestState = async (req: Request, res: Response) => {
   const existingRequest : WithId<RequestRecord> = await collection.findOne(filter);
 
   if (existingRequest){
+    // If neither the IDIR matches nor the user is admin, return the 403
     const userInfo = getUserInfo(req.headers.authorization.split(' ')[1]); // Excludes the 'Bearer' part of token.
-      if (userInfo.idir_user_guid !== existingRequest.idir && !userInfo.client_roles?.includes('admin')) return res.status(403).send('Forbidden: User does not match requested record.');
+    const idirMatches = userInfo.idir_user_guid === existingRequest.idir;
+    const isAdmin = userInfo.client_roles?.includes('admin');
+    if (!idirMatches && !isAdmin) return res.status(403).send('Forbidden: User does not match requested record.');
   }
 
   let refinedState = state;

--- a/api/docs/requests.yaml
+++ b/api/docs/requests.yaml
@@ -72,8 +72,8 @@ components:
 
     ReimbursementRequest:
       allOf:
-          - $ref: '#/components/schemas/ReimbursementRequestObject'
-          - type: object
+        - $ref: '#/components/schemas/ReimbursementRequestObject'
+        - type: object
       description: The received form data.
       properties:
         submissionDate:
@@ -215,6 +215,13 @@ paths:
                   $ref: '#/components/schemas/ReimbursementRequest'
         '400':
           $ref: '#/components/responses/400BadRequest'
+        '403':
+          description: Forbidden
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: 'Forbidden: User does not match requested IDIR.'
         '404':
           $ref: '#/components/responses/404NoRecords'
         '429':
@@ -339,11 +346,11 @@ paths:
         '400':
           $ref: '#/components/responses/400BadRequestID'
         '403':
-          #description: Forbidden
-            content:
-              text/plain:
-                schema:
-                  type: string
-                  example: 'An invalid state was requested.'
+          description: Forbidden
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: 'An invalid state was requested. || Forbidden: User does not match requested record.' 
         '429':
           $ref: '#/components/responses/429TooManyRequests'

--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
     "@bcgov/bc-sans": "1.0.1",
     "@emotion/react": "11.11.0",
     "@emotion/styled": "11.11.0",
+    "@mui/icons-material": "5.11.16",
     "@mui/material": "5.13.4",
     "@mui/x-date-pickers": "6.6.0",
     "axios": "1.4.0",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -10,6 +10,7 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import { KeycloakWrapper } from './keycloak';
 import { useAuthService } from './keycloak';
 import Login from './pages/Login';
+import UserRequests from './pages/UserRequests';
 
 /**
  * @returns Main element containing various providers and routes.
@@ -37,6 +38,7 @@ const App = () => {
               ? <Routes>
                   <Route index element={<Home/>} />
                   <Route path={'request/:id'} element={<IndividualRequest />}/>
+                  <Route path={'user/:idir'} element={<UserRequests />}/>
                 </Routes>
               : <Login/> }
             </div>

--- a/app/src/components/bcgov/NavigationBar.tsx
+++ b/app/src/components/bcgov/NavigationBar.tsx
@@ -3,6 +3,7 @@ import { headerFont } from "../../constants/fonts";
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import UserControl from "../custom/login/UserControl";
+import { useNavigate } from "react-router-dom";
 
 // Styles the header bar
 const headerStyle : React.CSSProperties = {
@@ -43,6 +44,7 @@ const bannerStyle : React.CSSProperties = {
 const NavigationBar = () => {
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.up('md'));
+  const navigate = useNavigate();
 
   return (
     <header style={headerStyle}>
@@ -52,7 +54,9 @@ const NavigationBar = () => {
             height: '45px'
           }}/>
         </a>
-        <h1 style={{ ...headerTextStyle, fontSize: matches ? '30px' : '18px' }}>Staff Purchase Reimbursement</h1>
+        <h1 onClick={() => {
+          navigate('/');
+        }} style={{ ...headerTextStyle, fontSize: matches ? '30px' : '18px', cursor: 'pointer' }}>Staff Purchase Reimbursement</h1>
       </div>
       <div
       style={{

--- a/app/src/components/custom/forms/RequestForm.tsx
+++ b/app/src/components/custom/forms/RequestForm.tsx
@@ -107,7 +107,7 @@ const RequestForm = (props: RequestFormProps) => {
             <Grid container xs={12} sx={{ justifyContent: 'space-between', display: 'flex' }}>
               <Grid xs={12} sm={6}><h4>Request ID: {reimbursementRequest?._id || 'No request found'}</h4></Grid>
               <Grid xs={12} sm={5} alignItems='center' justifyContent={matches ? 'flex-end' : 'flex-start'} style={{  minWidth: '215px', display: 'flex' }}>
-                <ActionButton style={{ ...buttonStyles.secondary, marginTop: '0.75em' }} handler={() => {navigate('/')}}>Back</ActionButton>
+                <ActionButton style={{ ...buttonStyles.secondary, marginTop: '0.75em' }} handler={() => {navigate(-1)}}>Back</ActionButton>
                 <ActionButton style={{ ...buttonStyles.primary, marginLeft: '1em', marginTop: '0.75em' }} handler={handleUpdate}>Update</ActionButton>
                 <IconButton
                   onClick={handleClick}

--- a/app/src/components/custom/forms/RequestForm.tsx
+++ b/app/src/components/custom/forms/RequestForm.tsx
@@ -1,8 +1,8 @@
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import { RequestStates, convertStateToStatus } from "../../../utils/convertState";
 import { useNavigate, useParams } from 'react-router-dom';
 import { ReimbursementRequest } from "../../../interfaces/ReimbursementRequest";
-import { Paper, TextField, Select, FormControl, FormLabel, MenuItem } from '@mui/material';
+import { Paper, TextField, Select, FormControl, FormLabel, MenuItem, Menu, IconButton } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2/Grid2';
 import { DatePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
@@ -16,6 +16,7 @@ import ApprovalTable from "../../../components/custom/tables/ApprovalTable";
 import { IFile } from "../../../interfaces/IFile";
 import { Purchase } from "../../../interfaces/Purchase";
 import { Approval } from "../../../interfaces/Approval";
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 
 /**
  * @interface
@@ -71,6 +72,16 @@ const RequestForm = (props: RequestFormProps) => {
     setApprovalFiles
   } = props;
 
+  // Controls for menu dropdown
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.up('sm'));
   const navigate = useNavigate();
@@ -98,6 +109,60 @@ const RequestForm = (props: RequestFormProps) => {
               <Grid xs={12} sm={5} alignItems='center' justifyContent={matches ? 'flex-end' : 'flex-start'} style={{  minWidth: '215px', display: 'flex' }}>
                 <ActionButton style={{ ...buttonStyles.secondary, marginTop: '0.75em' }} handler={() => {navigate('/')}}>Back</ActionButton>
                 <ActionButton style={{ ...buttonStyles.primary, marginLeft: '1em', marginTop: '0.75em' }} handler={handleUpdate}>Update</ActionButton>
+                <IconButton
+                  onClick={handleClick}
+                  size="small"
+                  sx={{ ml: 2, margin: '0.75em 0 0 0' }}
+                  aria-controls={open ? 'account-menu' : undefined}
+                  aria-haspopup="true"
+                  aria-expanded={open ? 'true' : undefined}
+                >
+                  <MoreVertIcon fontSize="large"/>
+                </IconButton>
+                <Menu
+                  anchorEl={anchorEl}
+                  id="account-menu"
+                  open={open}
+                  onClose={handleClose}
+                  onClick={handleClose}
+                  PaperProps={{
+                    elevation: 0,
+                    sx: {
+                      overflow: 'visible',
+                      filter: 'drop-shadow(0px 2px 8px rgba(0,0,0,0.32))',
+                      mt: 1.5,
+                      '& .MuiAvatar-root': {
+                        width: 32,
+                        height: 32,
+                        ml: -0.5,
+                        mr: 1,
+                      },
+                      '&:before': {
+                        content: '""',
+                        display: 'block',
+                        position: 'absolute',
+                        top: 0,
+                        right: 14,
+                        width: 10,
+                        height: 10,
+                        bgcolor: 'background.paper',
+                        transform: 'translateY(-50%) rotate(45deg)',
+                        zIndex: 0,
+                      },
+                    },
+                  }}
+                  transformOrigin={{ horizontal: 'right', vertical: 'top' }}
+                  anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+                >
+                  <MenuItem onClick={() => { navigate(`/user/${reimbursementRequest?.idir}`); }}>
+                    View User's Requests
+                  </MenuItem>
+                  {/* 
+                  Will be addressed in upcoming ticket.
+                  <MenuItem onClick={handleClose}>
+                    Delete Request
+                  </MenuItem> */}
+                </Menu>
               </Grid>
             </Grid>
 

--- a/app/src/components/custom/login/UserControl.tsx
+++ b/app/src/components/custom/login/UserControl.tsx
@@ -99,9 +99,6 @@ const UserControl = () => {
                       aria-labelledby="composition-button"
                       onKeyDown={handleListKeyDown}
                     >
-                      { // TODO: Use this item to redirect to IDIR-filtered requests when implemented
-                      /* <MenuItem onClick={handleClose}>My Requests</MenuItem> */
-                      }
                       <MenuItem onClick={() => {window.location.href = getLogoutURL();}} >Logout</MenuItem>
                     </MenuList>
                   </ClickAwayListener>

--- a/app/src/components/custom/tables/RequestsTable.tsx
+++ b/app/src/components/custom/tables/RequestsTable.tsx
@@ -13,7 +13,6 @@ import { convertStateToStatus } from '../../../utils/convertState';
 import { bcgov } from '../../../constants/colours';
 import LinkButton from '../../bcgov/LinkButton';
 import { buttonStyles } from '../../bcgov/ButtonStyles';
-import { useParams } from 'react-router-dom';
 
 /**
  * @interface

--- a/app/src/components/custom/tables/RequestsTable.tsx
+++ b/app/src/components/custom/tables/RequestsTable.tsx
@@ -13,6 +13,7 @@ import { convertStateToStatus } from '../../../utils/convertState';
 import { bcgov } from '../../../constants/colours';
 import LinkButton from '../../bcgov/LinkButton';
 import { buttonStyles } from '../../bcgov/ButtonStyles';
+import { useParams } from 'react-router-dom';
 
 /**
  * @interface
@@ -30,6 +31,7 @@ interface RequestTableProps {
  */
 const RequestsTable = (props: RequestTableProps) => {
   const { data } = props;
+
   return (
     <TableContainer component={Paper}>
       <Table aria-label='simple table'>

--- a/app/src/pages/Home.tsx
+++ b/app/src/pages/Home.tsx
@@ -32,7 +32,6 @@ const Home = () => {
 
   // Retrieves a list of all reimbursement requests and updates state.
   const getRequests = useCallback(async () => {
-    console.log(isAdmin)
     const targetURL = adminView
                       ? `${BACKEND_URL}/api/requests?minimal=true`
                       : `${BACKEND_URL}/api/requests/idir?minimal=true&idir=${authState.userInfo.idir_user_guid}`;

--- a/app/src/pages/Home.tsx
+++ b/app/src/pages/Home.tsx
@@ -5,6 +5,7 @@ import RequestsTable from '../components/custom/tables/RequestsTable';
 import { headerFont } from '../constants/fonts';
 import { useAuthService } from '../keycloak';
 import { useNavigate } from 'react-router-dom';
+import { Switch } from '@mui/material';
 
 /**
  * @description The Home page, showing a list of reimbursement requests. 
@@ -14,6 +15,8 @@ const Home = () => {
   const [requests, setRequests] = useState([]);
   const { BACKEND_URL, FRONTEND_URL } = Constants;
   const { state: authState } = useAuthService();
+  const isAdmin = authState.userInfo.client_roles?.includes('admin');
+  const [adminView, setAdminView] = useState<boolean>(isAdmin);
   const navigate = useNavigate();
 
   // Fires on page load.
@@ -25,12 +28,15 @@ const Home = () => {
     } else {
       getRequests();
     }
-  }, []);
+  }, [adminView]);
 
-  // Retrieves a list of reimbursement requests and updates state.
+  // Retrieves a list of all reimbursement requests and updates state.
   const getRequests = useCallback(async () => {
+    const targetURL = adminView
+                      ? `${BACKEND_URL}/api/requests?minimal=true`
+                      : `${BACKEND_URL}/api/requests/idir?minimal=true&idir=${authState.userInfo.idir_user_guid}`;
     try {
-      const { data } = await axios.get(`${BACKEND_URL}/api/requests?minimal=true`, {
+      const { data } = await axios.get(targetURL, {
         headers: {
           Authorization : `Bearer ${authState.accessToken}`
         }
@@ -39,11 +45,32 @@ const Home = () => {
     } catch (e) {
       console.warn('Server could not be reached.');
     }
-  }, []);
+  }, [adminView]);
 
   return (
     <>
-      <h2 style={headerFont}>Reimbursement Requests</h2>
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'flex-end'
+      }}>
+        <h2 style={headerFont}>Reimbursement Requests</h2>
+        {
+          isAdmin
+          ? <div style={{
+                margin: '1em 0 1em 1em'
+              }}>
+              <span style={headerFont}>Admin View</span>
+              <Switch 
+                value={adminView} 
+                onChange={(e) => {
+                  setAdminView(!adminView);
+                }}
+              />
+            </div>   
+          : <></>
+        }
+      </div>  
       <RequestsTable data={requests} />
     </>
   );

--- a/app/src/pages/Home.tsx
+++ b/app/src/pages/Home.tsx
@@ -32,6 +32,7 @@ const Home = () => {
 
   // Retrieves a list of all reimbursement requests and updates state.
   const getRequests = useCallback(async () => {
+    console.log(isAdmin)
     const targetURL = adminView
                       ? `${BACKEND_URL}/api/requests?minimal=true`
                       : `${BACKEND_URL}/api/requests/idir?minimal=true&idir=${authState.userInfo.idir_user_guid}`;
@@ -62,7 +63,7 @@ const Home = () => {
               }}>
               <span style={headerFont}>Admin View</span>
               <Switch 
-                value={adminView} 
+                checked={adminView} 
                 onChange={(e) => {
                   setAdminView(!adminView);
                 }}

--- a/app/src/pages/IndividualRequest.tsx
+++ b/app/src/pages/IndividualRequest.tsx
@@ -126,7 +126,7 @@ const IndividualRequest = () => {
       let response = await axios(axiosReqConfig);
       if (response.status === 200) {
         // Return to home page
-        navigate('/');
+        navigate(-1);
       }
     } catch (e) {
       console.warn('Record could not be updated.');

--- a/app/src/pages/UserRequests.tsx
+++ b/app/src/pages/UserRequests.tsx
@@ -8,7 +8,7 @@ import { useParams } from 'react-router-dom';
 
 const UserRequests = () => {
   const [requests, setRequests] = useState([]);
-  const { BACKEND_URL, FRONTEND_URL } = Constants;
+  const { BACKEND_URL } = Constants;
   const { state: authState } = useAuthService();
   const isAdmin = authState.userInfo.client_roles?.includes('admin');
   const { idir } = useParams();

--- a/app/src/pages/UserRequests.tsx
+++ b/app/src/pages/UserRequests.tsx
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useState } from 'react';
+import Constants from '../constants/Constants';
+import axios from 'axios';
+import RequestsTable from '../components/custom/tables/RequestsTable';
+import { headerFont } from '../constants/fonts';
+import { useAuthService } from '../keycloak';
+import { useParams } from 'react-router-dom';
+
+const UserRequests = () => {
+  const [requests, setRequests] = useState([]);
+  const { BACKEND_URL, FRONTEND_URL } = Constants;
+  const { state: authState } = useAuthService();
+  const isAdmin = authState.userInfo.client_roles?.includes('admin');
+  const { idir } = useParams();
+
+  // Fires on page load.
+  useEffect(() => {
+    if (isAdmin){
+      getRequests();
+    } else {
+      console.warn('User is not permitted to view these records.')
+    }
+  }, []);
+
+  // Retrieves a list of all reimbursement requests and updates state.
+  const getRequests = useCallback(async () => {
+    const targetURL = `${BACKEND_URL}/api/requests/idir?minimal=true&idir=${idir}`;
+    try {
+      const { data } = await axios.get(targetURL, {
+        headers: {
+          Authorization : `Bearer ${authState.accessToken}`
+        }
+      })
+      setRequests(data);
+    } catch (e) {
+      console.warn('Server could not be reached.');
+    }
+  }, []);
+
+  if (!isAdmin){
+    return (<>
+      <h1>You do not have permission to view this page.</h1>
+      <p>If you think you are seeing this by mistake, contact your administrator.</p>
+    </>);
+  } else
+
+  return (
+    <>
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'flex-end'
+      }}>
+        <h2 style={headerFont}>Reimbursement Requests</h2>
+      </div>  
+      <RequestsTable data={requests} />
+    </>
+  );
+}
+
+export default UserRequests;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Add a toggle for admins on main page to just see their records
- Added a page that just shows an individual IDIR's records and an option on an individual record to get there.
- Corrected the Back and Update button redirects to go back to the correct page, depending on where they came from
- Added a navigate to the page's title, to take a user to the home page.
- Added checks to the requests API route for whether the user matches the record they're trying to access and if that user is an admin. If neither of these things are true, the request is denied with a 403. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
- [x] Dependencies added/removed

## Aspect(s) of Project Affected
- [x] Frontend
- [x] API
- [ ] Database
- [ ] Workflows
- [x] Documentation

## Best Practices Checklist
- [x] I have performed a self-review of my own code
- [x] My code follows the Airbnb React Style Guidelines
- [x] Documentation has been updated to reflect my changes
- [x] New and existing tests pass locally with my changes

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Tested locally in dev and containers.
