### PR TITLE
SPR-163 BUG-FIX: Colour of text on cost filter not visible

### DIFF
--- a/app/src/components/custom/searchFields/CurrencyComparer.tsx
+++ b/app/src/components/custom/searchFields/CurrencyComparer.tsx
@@ -1,7 +1,8 @@
-import { Button, ButtonGroup, TextField, InputAdornment } from '@mui/material';
+import { Button, ButtonGroup, TextField, InputAdornment, Typography } from '@mui/material';
 import { buttonStyles } from '../../bcgov/ButtonStyles';
 import React from 'react';
 import { bcgov } from '../../../constants/colours';
+import { normalFont } from '../../../constants/fonts';
 
 /**
  * @description Defines the properties for the Currency Comparer component.
@@ -55,9 +56,18 @@ const CurrencyComparer = (props: CurrencyComparerProps) => {
           aria-description='Changes the filter to look for greater or equal to versus less or equal to the value.'
           onClick={changeSymbol}
         >
-          <div id='symbol' style={{ color: bcgov.component }}>
+          <Typography
+            id='symbol'
+            sx={{
+              ...normalFont,
+              color: bcgov.component,
+              '&:hover': {
+                color: bcgov.white,
+              },
+            }}
+          >
             {'>='}
-          </div>
+          </Typography>
         </Button>
         <TextField
           variant='standard'


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Added color on hover for cost filter button
- Switched to typography and applied normal font styling

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
- [ ] Dependencies added/removed

## Aspect(s) of Project Affected
- [x] Frontend
- [ ] API
- [ ] Database
- [ ] Workflows
- [ ] Documentation

## Best Practices Checklist
- [x] I have performed a self-review of my own code
- [x] My code follows the Airbnb React Style Guidelines
- [ ] Documentation has been updated to reflect my changes
- [ ] New and existing tests pass locally with my changes

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Verified on local build.
