### PR TITLE
SPR-158 Request Table Remember Filter

### DIFF
--- a/app/src/components/custom/searchFields/CurrencyComparer.tsx
+++ b/app/src/components/custom/searchFields/CurrencyComparer.tsx
@@ -9,12 +9,14 @@ import { normalFont } from '../../../constants/fonts';
  * @interface
  * @property {React.CSSProperties}  sx              Style properties for the component.
  * @property {string}               value           The number value as a string.
+ * @property {Symbols}              buttonValue     The enum value that determines the button's visible symbol.
  * @property {(e: any) => void}     changeSymbol    Updates the symbol used in the filter's comparison.
  * @property {(e: any) => void}     onChange        Function called when value of the component changes.
  */
 interface CurrencyComparerProps {
   sx: React.CSSProperties;
   value: string;
+  buttonValue: Symbols;
   changeSymbol: (e: any) => void;
   onChange: (e: any) => void;
 }
@@ -34,7 +36,7 @@ export enum Symbols {
  * @returns A React component.
  */
 const CurrencyComparer = (props: CurrencyComparerProps) => {
-  const { sx, value, changeSymbol, onChange } = props;
+  const { sx, value, buttonValue, changeSymbol, onChange } = props;
 
   return (
     <>
@@ -66,7 +68,7 @@ const CurrencyComparer = (props: CurrencyComparerProps) => {
               },
             }}
           >
-            {'>='}
+            {buttonValue === Symbols.GT ? '>=' : '<='}
           </Typography>
         </Button>
         <TextField

--- a/app/src/components/custom/tables/RequestsTable.tsx
+++ b/app/src/components/custom/tables/RequestsTable.tsx
@@ -405,29 +405,17 @@ const RequestsTable = (props: RequestTableProps) => {
    * @description Changes the symbol in the CurrencyComparer component when clicked. Also updates the dataManipulator.
    */
   const changeSymbol = () => {
-    if (dataManipulator.cost.filter.symbol === Symbols.GT) {
-      setDataManipulator({
-        ...dataManipulator,
-        cost: {
-          ...dataManipulator.cost,
-          filter: {
-            ...dataManipulator.cost.filter,
-            symbol: Symbols.LT,
-          },
+    const newSymbol = dataManipulator.cost.filter.symbol === Symbols.GT ? Symbols.LT : Symbols.GT;
+    setDataManipulator({
+      ...dataManipulator,
+      cost: {
+        ...dataManipulator.cost,
+        filter: {
+          ...dataManipulator.cost.filter,
+          symbol: newSymbol,
         },
-      });
-    } else {
-      setDataManipulator({
-        ...dataManipulator,
-        cost: {
-          ...dataManipulator.cost,
-          filter: {
-            ...dataManipulator.cost.filter,
-            symbol: Symbols.GT,
-          },
-        },
-      });
-    }
+      },
+    });
   };
 
   /**

--- a/app/src/components/custom/tables/RequestsTable.tsx
+++ b/app/src/components/custom/tables/RequestsTable.tsx
@@ -125,6 +125,7 @@ const RequestsTable = (props: RequestTableProps) => {
     },
   };
 
+  // Gets the stored value from local storage or sets the default value if there is none.
   const getStartingDataManipulator = () => {
     if (sessionStorage.getItem('dataManipulator')) {
       return JSON.parse(sessionStorage.getItem('dataManipulator')!) as DataManipulatorObject;
@@ -137,12 +138,14 @@ const RequestsTable = (props: RequestTableProps) => {
   const [dataManipulator, setDataManipulator] = useState<DataManipulatorObject>(
     getStartingDataManipulator(),
   );
+
   // Pagination state. Used to break the records into pages.
   const [paginationControlObject, setPaginationControlObject] = useState<PaginationControlObject>({
     currentPage: 1,
     rowsPerPage: 30,
     totalRecords: data.length,
   });
+
   // Page data, the info only shown on the current page. e.g. 1 of 3
   const [pageData, setPageData] = useState<Array<ReimbursementRequest>>(propData);
   const { state: authState } = useAuthService();
@@ -171,15 +174,6 @@ const RequestsTable = (props: RequestTableProps) => {
       ),
     );
   }, [paginationControlObject]);
-
-  // Load existing data manipulator settings if they exist in session storage
-  useEffect(() => {
-    if (sessionStorage.getItem('dataManipulator')) {
-      setDataManipulator(
-        JSON.parse(sessionStorage.getItem('dataManipulator')!) as DataManipulatorObject,
-      );
-    }
-  }, []);
 
   /**
    * @description Sorts the data in the table based on the dataManipulator state object.
@@ -411,33 +405,28 @@ const RequestsTable = (props: RequestTableProps) => {
    * @description Changes the symbol in the CurrencyComparer component when clicked. Also updates the dataManipulator.
    */
   const changeSymbol = () => {
-    const symbolDiv = document.getElementById('symbol');
-    if (symbolDiv) {
-      if (dataManipulator.cost.filter.symbol === Symbols.GT) {
-        setDataManipulator({
-          ...dataManipulator,
-          cost: {
-            ...dataManipulator.cost,
-            filter: {
-              ...dataManipulator.cost.filter,
-              symbol: Symbols.LT,
-            },
+    if (dataManipulator.cost.filter.symbol === Symbols.GT) {
+      setDataManipulator({
+        ...dataManipulator,
+        cost: {
+          ...dataManipulator.cost,
+          filter: {
+            ...dataManipulator.cost.filter,
+            symbol: Symbols.LT,
           },
-        });
-        symbolDiv.innerHTML = '<=';
-      } else {
-        setDataManipulator({
-          ...dataManipulator,
-          cost: {
-            ...dataManipulator.cost,
-            filter: {
-              ...dataManipulator.cost.filter,
-              symbol: Symbols.GT,
-            },
+        },
+      });
+    } else {
+      setDataManipulator({
+        ...dataManipulator,
+        cost: {
+          ...dataManipulator.cost,
+          filter: {
+            ...dataManipulator.cost.filter,
+            symbol: Symbols.GT,
           },
-        });
-        symbolDiv.innerHTML = '>=';
-      }
+        },
+      });
     }
   };
 
@@ -561,6 +550,7 @@ const RequestsTable = (props: RequestTableProps) => {
                 <CurrencyComparer
                   sx={{ ...filterStyle }}
                   value={dataManipulator.cost.filter.value}
+                  buttonValue={dataManipulator.cost.filter.symbol}
                   onChange={updateCostFilter}
                   {...{ changeSymbol }}
                 />

--- a/app/src/components/custom/tables/RequestsTable.tsx
+++ b/app/src/components/custom/tables/RequestsTable.tsx
@@ -125,8 +125,18 @@ const RequestsTable = (props: RequestTableProps) => {
     },
   };
 
+  const getStartingDataManipulator = () => {
+    if (sessionStorage.getItem('dataManipulator')) {
+      return JSON.parse(sessionStorage.getItem('dataManipulator')!) as DataManipulatorObject;
+    } else {
+      return defaultManipulator;
+    }
+  };
+
   // Data manipulation state. Filtering and sorting.
-  const [dataManipulator, setDataManipulator] = useState<DataManipulatorObject>(defaultManipulator);
+  const [dataManipulator, setDataManipulator] = useState<DataManipulatorObject>(
+    getStartingDataManipulator(),
+  );
   // Pagination state. Used to break the records into pages.
   const [paginationControlObject, setPaginationControlObject] = useState<PaginationControlObject>({
     currentPage: 1,
@@ -149,6 +159,7 @@ const RequestsTable = (props: RequestTableProps) => {
       currentPage: 1,
       totalRecords: sortedData.length,
     });
+    sessionStorage.setItem('dataManipulator', JSON.stringify(dataManipulator));
   }, [propData, dataManipulator]);
 
   // Slices the data in to a page's worth of records if the pagination control changes.
@@ -160,6 +171,15 @@ const RequestsTable = (props: RequestTableProps) => {
       ),
     );
   }, [paginationControlObject]);
+
+  // Load existing data manipulator settings if they exist in session storage
+  useEffect(() => {
+    if (sessionStorage.getItem('dataManipulator')) {
+      setDataManipulator(
+        JSON.parse(sessionStorage.getItem('dataManipulator')!) as DataManipulatorObject,
+      );
+    }
+  }, []);
 
   /**
    * @description Sorts the data in the table based on the dataManipulator state object.
@@ -450,6 +470,7 @@ const RequestsTable = (props: RequestTableProps) => {
    */
   const resetFilter = () => {
     setDataManipulator(defaultManipulator);
+    sessionStorage.removeItem('dataManipulator');
   };
 
   const filterStyle = {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Table sorting and filtering would previously be reset when the user left the page and returned. 
- Now that configuration is also stored in session storage, so it can be reloaded when the page loads.
- Changed the way the cost filter button works. It now manages its own text. This fixes a bug where the filter value would be saved, but the symbol was not matching after reloading the page.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
- [ ] Dependencies added/removed

## Aspect(s) of Project Affected
- [x] Frontend
- [ ] API
- [ ] Database
- [ ] Workflows
- [ ] Documentation

## Best Practices Checklist
- [x] I have performed a self-review of my own code
- [x] My code follows the Airbnb React Style Guidelines
- [x] Documentation has been updated to reflect my changes
- [x] New and existing tests pass locally with my changes

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Tested locally through manual use.
