### PR TITLE
SPR-188 Update Button Visibility

### DIFF
--- a/app/src/components/custom/forms/RequestForm.tsx
+++ b/app/src/components/custom/forms/RequestForm.tsx
@@ -291,6 +291,7 @@ const RequestForm = (props: RequestFormProps) => {
                   style={{ ...buttonStyles.primary, marginLeft: '1em' }}
                   handler={onUpdate}
                   ariaDescription='Updates the record with the info currently displayed.'
+                  disabled={locked}
                 >
                   Update
                 </ActionButton>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- The Update button is now disabled if the request record isn't editable. Before it would just essentially resubmit the same info, but why allow that? 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
- [ ] Dependencies added/removed

## Aspect(s) of Project Affected
- [x] Frontend
- [ ] API
- [ ] Database
- [ ] Workflows
- [ ] Documentation

## Best Practices Checklist
- [x] I have performed a self-review of my own code
- [x] My code follows the Airbnb React Style Guidelines
- [x] Documentation has been updated to reflect my changes
- [x] New and existing tests pass locally with my changes

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Tested manually in UI
