### PR TITLE
SPR-192 Update Downloaded Triggers

### DIFF
--- a/api/helpers/checkForCompleteRequest.ts
+++ b/api/helpers/checkForCompleteRequest.ts
@@ -25,16 +25,17 @@ export const checkForCompleteRequest = (requestData: RequestUpdateData) => {
 
   // Do all purchases have a file?
   const purchasesHaveFiles = requestData.purchases.every(
-    (purchase: Purchase) => purchase.fileObj && !purchase.fileObj.removed,
+    (purchase: Purchase) =>
+      purchase.fileObj && !purchase.fileObj.removed && purchase.fileObj.source !== 'temp',
   );
   if (!purchasesHaveFiles) return false;
-
   // Does at least one approval exist?
   if (requestData.approvals.length === 0) return false;
 
   // Does each approval have a file?
   const approvalsHaveFiles = requestData.approvals.every(
-    (approval: Approval) => approval.fileObj && !approval.fileObj.removed,
+    (approval: Approval) =>
+      approval.fileObj && !approval.fileObj.removed && approval.fileObj.source !== 'temp',
   );
   if (!approvalsHaveFiles) return false;
 

--- a/api/keycloak/utils.ts
+++ b/api/keycloak/utils.ts
@@ -127,3 +127,17 @@ export const getUserInfo = (access_token: string) => {
   if (!data) return null;
   return data.payload;
 };
+
+// Describes the user info contained in the request
+export interface User {
+  idir_user_guid: string;
+  identity_provider: string;
+  idir_username: string;
+  name: string;
+  preferred_username: string;
+  given_name: string;
+  display_name: string;
+  family_name: string;
+  email: string;
+  client_roles?: string[];
+}

--- a/app/src/components/custom/fileHandlers/FileLink.tsx
+++ b/app/src/components/custom/fileHandlers/FileLink.tsx
@@ -10,6 +10,7 @@ import { useAuthService } from '../../../keycloak';
 import { useParams } from 'react-router-dom';
 import DownloadDoneIcon from '@mui/icons-material/DownloadDone';
 import { ErrorContext, errorStyles } from '../notifications/ErrorWrapper';
+import { User } from '../../../keycloak/utils/User';
 
 /**
  * @interface
@@ -38,6 +39,7 @@ interface FileLinkProps {
 const FileLink = (props: FileLinkProps) => {
   const { uid, files, setFiles, index, source, disabled } = props;
   const { state: authState } = useAuthService();
+  const isAdmin = (authState.userInfo as User).client_roles?.includes('admin');
   const { id } = useParams();
   const { BACKEND_URL } = Constants;
 
@@ -76,10 +78,12 @@ const FileLink = (props: FileLinkProps) => {
     tempLink.download = files[index].name;
     tempLink.click();
 
-    // Mark file as downloaded
-    const tempFiles = [...files];
-    tempFiles[index].downloaded = true;
-    setFiles(tempFiles);
+    // Mark file as downloaded, only if admin
+    if (isAdmin) {
+      const tempFiles = [...files];
+      tempFiles[index].downloaded = true;
+      setFiles(tempFiles);
+    }
   };
 
   return (

--- a/app/src/components/custom/fileHandlers/FileLink.tsx
+++ b/app/src/components/custom/fileHandlers/FileLink.tsx
@@ -108,7 +108,7 @@ const FileLink = (props: FileLinkProps) => {
         }}
         style={{ ...normalFont, color: bcgov.links, marginRight: '1em' }}
       >{`${files[index].name}`}</a>
-      {files[index].downloaded ? (
+      {isAdmin && files[index].downloaded ? (
         <Tooltip title='Previously Downloaded'>
           <DownloadDoneIcon
             fontSize='medium'

--- a/app/src/components/custom/forms/RequestForm.tsx
+++ b/app/src/components/custom/forms/RequestForm.tsx
@@ -210,6 +210,14 @@ const RequestForm = (props: RequestFormProps) => {
     }
   };
 
+  // Marks all files in a list of Purchases or Approvals as downloaded
+  const markAllFilesAsDownloaded = (list: IFile[]) =>
+    list.map((file: IFile) => {
+      const tempFile = { ...file };
+      tempFile.downloaded = true;
+      return tempFile;
+    });
+
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.up('sm'));
   const navigate = useNavigate();
@@ -346,6 +354,8 @@ const RequestForm = (props: RequestFormProps) => {
                         onClick={() => {
                           try {
                             getAllFiles(reimbursementRequest?._id || '', authState.accessToken);
+                            setPurchaseFiles(markAllFilesAsDownloaded(purchaseFiles));
+                            setApprovalFiles(markAllFilesAsDownloaded(approvalFiles));
                           } catch (e: any) {
                             setErrorState({
                               text: 'File could not be retrieved.',

--- a/app/src/helpers/fileDownloadAll.ts
+++ b/app/src/helpers/fileDownloadAll.ts
@@ -15,7 +15,11 @@ export const getAllFiles = async (id: string, token: string) => {
       Authorization: `Bearer ${token}`,
     },
   };
-  const file: string = await axios(axiosReqConfig).then((response) => response.data.zip);
+  const file: string = await axios(axiosReqConfig)
+    .then((response) => response.data.zip)
+    .catch(() => {
+      throw Error('File retrieval failed.');
+    });
   const tempLink = document.createElement('a');
   tempLink.href = file;
   tempLink.download = `allFiles${id}.zip`;

--- a/app/src/keycloak/utils/User.ts
+++ b/app/src/keycloak/utils/User.ts
@@ -1,0 +1,13 @@
+// Describes the user info contained in the request
+export interface User {
+  idir_user_guid: string;
+  identity_provider: string;
+  idir_username: string;
+  name: string;
+  preferred_username: string;
+  given_name: string;
+  display_name: string;
+  family_name: string;
+  email: string;
+  client_roles?: string[];
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Changed visibility of downloaded icon to only be seen by admin. 
- Only admins can now trigger the downloaded status. 
- This also now happens in the API only if instigated by an admin.
- Download all files updates UI with download icons.
- Added User interface for Keycloak. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
- [ ] Dependencies added/removed

## Aspect(s) of Project Affected
- [x] Frontend
- [x] API
- [ ] Database
- [ ] Workflows
- [ ] Documentation

## Best Practices Checklist
- [x] I have performed a self-review of my own code
- [x] My code follows the Airbnb React Style Guidelines
- [x] Documentation has been updated to reflect my changes
- [x] New and existing tests pass locally with my changes

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Tested manually in the UI.
